### PR TITLE
Add Umbraco SEO property editor example

### DIFF
--- a/seo-property-editor/Controllers/SeoContentGeneratorApiController.cs
+++ b/seo-property-editor/Controllers/SeoContentGeneratorApiController.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Web.BackOffice.Controllers;
+using Umbraco.Cms.Web.Common.Attributes;
+
+namespace SeoPropertyEditor.Controllers
+{
+    [PluginController("SeoPropertyEditor")]
+    public class SeoContentGeneratorApiController : UmbracoAuthorizedApiController
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<SeoContentGeneratorApiController> _logger;
+
+        public SeoContentGeneratorApiController(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<SeoContentGeneratorApiController> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Generate([FromBody] SeoRequest request)
+        {
+            if (request == null || request.Fields == null)
+            {
+                return BadRequest("No fields provided");
+            }
+
+            var apiKey = _configuration["OpenAI:ApiKey"];
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                return StatusCode(500, "API key not configured");
+            }
+
+            var prompt = string.Join(" \n", request.Fields.Select(f => f.Value));
+            var http = _httpClientFactory.CreateClient();
+            http.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+
+            var body = new
+            {
+                model = "gpt-3.5-turbo",
+                messages = new [] {
+                    new { role = "system", content = "You are an SEO assistant." },
+                    new { role = "user", content = $"Generate SEO optimized text based on the following content: {prompt}" }
+                }
+            };
+
+            var response = await http.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", body);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("OpenAI request failed: {StatusCode}", response.StatusCode);
+                return StatusCode((int)response.StatusCode, "AI request failed");
+            }
+
+            var resultJson = await response.Content.ReadFromJsonAsync<OpenAiResponse>();
+            var generated = resultJson?.choices?.FirstOrDefault()?.message?.content ?? string.Empty;
+            return Ok(generated);
+        }
+    }
+
+    public class SeoRequest
+    {
+        public Dictionary<string, string>? Fields { get; set; }
+    }
+
+    public class OpenAiResponse
+    {
+        public List<Choice>? choices { get; set; }
+    }
+
+    public class Choice
+    {
+        public OpenAiMessage? message { get; set; }
+    }
+
+    public class OpenAiMessage
+    {
+        public string? content { get; set; }
+    }
+}

--- a/seo-property-editor/README.md
+++ b/seo-property-editor/README.md
@@ -1,0 +1,31 @@
+# Umbraco SEO Property Editor
+
+This sample demonstrates how to create a simple property editor for Umbraco v14-v16 that collects text from specified field names and uses an AI service to generate SEO optimized content.
+
+The property editor reads an API key from `appsettings.json` and posts the selected field values to a custom API controller which communicates with OpenAI (or any compatible service). The response is displayed in the editor for content editors to use.
+
+## Files
+
+- `SeoContentGeneratorDataEditor.cs` – registers the property editor.
+- `SeoContentGeneratorApiController.cs` – API controller that calls the AI service.
+- `Views/SeoContentGeneratorEditor.html` – simple UI for the editor.
+- `wwwroot/js/seoEditor.controller.js` – AngularJS controller logic.
+
+## appsettings.json snippet
+
+```json
+{
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY"
+  }
+}
+```
+
+## Usage
+
+1. Copy these files into an Umbraco web project under `~/App_Plugins/SeoPropertyEditor`.
+2. Add your API key to `appsettings.json` under the `OpenAI` section.
+3. Build and run the project. The editor can now be added to document types.
+4. Configure the editor with the field names you want to crawl (e.g., `name,title,body`). When the button is clicked, the AI-generated SEO text will appear in the editor.
+
+This code is meant as a starting point and may require adjustments depending on your project setup.

--- a/seo-property-editor/SeoContentGeneratorDataEditor.cs
+++ b/seo-property-editor/SeoContentGeneratorDataEditor.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Composing;
+
+namespace SeoPropertyEditor
+{
+    [DataEditor(
+        alias: "SeoContentGenerator",
+        name: "SEO Content Generator",
+        view: "/App_Plugins/SeoPropertyEditor/Views/SeoContentGeneratorEditor.html",
+        ValueType = ValueTypes.Text,
+        Group = "SEO"]
+    )]
+    public class SeoContentGeneratorDataEditor : DataEditor
+    {
+        public SeoContentGeneratorDataEditor(IDataValueEditorFactory dataValueEditorFactory, ILogger<SeoContentGeneratorDataEditor> logger)
+            : base(dataValueEditorFactory, logger)
+        {
+        }
+
+        protected override IConfigurationEditor CreateConfigurationEditor() => new SeoContentGeneratorConfiguration();
+
+        public class SeoContentGeneratorConfiguration : ConfigurationEditor<Dictionary<string, object>>
+        {
+        }
+    }
+}

--- a/seo-property-editor/Views/SeoContentGeneratorEditor.html
+++ b/seo-property-editor/Views/SeoContentGeneratorEditor.html
@@ -1,0 +1,13 @@
+<div ng-controller="seoEditorController as vm">
+    <umb-box>
+        <umb-box-content>
+            <umb-property label="Fields" description="Comma separated list of field aliases">
+                <input type="text" ng-model="vm.fieldNames" placeholder="name,title,body" />
+            </umb-property>
+            <umb-property label="Generated SEO Text">
+                <textarea ng-model="model.value" rows="10"></textarea>
+            </umb-property>
+            <umb-button label="Generate" action="vm.generate()" type="button" button-style="action"></umb-button>
+        </umb-box-content>
+    </umb-box>
+</div>

--- a/seo-property-editor/package.manifest
+++ b/seo-property-editor/package.manifest
@@ -1,0 +1,5 @@
+{
+  "javascript": [
+    "~/App_Plugins/SeoPropertyEditor/wwwroot/js/seoEditor.controller.js"
+  ]
+}

--- a/seo-property-editor/wwwroot/js/seoEditor.controller.js
+++ b/seo-property-editor/wwwroot/js/seoEditor.controller.js
@@ -1,0 +1,28 @@
+(function () {
+    'use strict';
+
+    function seoEditorController($scope, $http) {
+        var vm = this;
+        vm.fieldNames = '';
+
+        vm.generate = function () {
+            if (!vm.fieldNames) {
+                return;
+            }
+            var names = vm.fieldNames.split(',').map(function (n) { return n.trim(); });
+            var fields = {};
+            names.forEach(function(name){
+                var value = $scope.$parent.$parent.content[name];
+                if (value) {
+                    fields[name] = value;
+                }
+            });
+            $http.post('/umbraco/backoffice/SeoPropertyEditor/SeoContentGeneratorApi/Generate', { fields: fields })
+                .then(function (res) {
+                    $scope.model.value = res.data;
+                });
+        };
+    }
+
+    angular.module('umbraco').controller('seoEditorController', seoEditorController);
+})();


### PR DESCRIPTION
## Summary
- add `Umbraco SEO Property Editor` sample with C# code, Angular controller, and view
- include README instructions and manifest for plugin registration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c08e0409c832d9aa5118715c4fe5a